### PR TITLE
plots autoresize; plus other fixes

### DIFF
--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -110,12 +110,16 @@ when not defined(js):
                               "title", title, "saveImage", imageInject]
 
   proc save*(p: SomePlot, path = "", html_template = defaultTmplString, filename = ""): string =
+    let tempName = "D20190125T182937.html"
+      # unlikely to conflict with other applications
+      # TODO: implement https://github.com/brentp/nim-plotly/issues/20
+
     result = path
     if result == "":
       when defined(Windows):
-        result = getEnv("TEMP") / "x.html"
+        result = getEnv("TEMP") / tempName
       else:
-        result = "/tmp/x.html"
+        result = "/tmp/" & tempName
 
     when type(p) is Plot:
       # convert traces to data suitable for plotly and fill Html template
@@ -123,13 +127,7 @@ when not defined(js):
     else:
       let data_string = $p.traces
     let html = html_template.fillHtmlTemplate(data_string, p, filename)
-
-    var
-      f: File
-    if not open(f, result, fmWrite):
-      quit "could not open file for json"
-    f.write(html)
-    f.close()
+    writeFile(result, html)
 
   when not hasThreadSupport:
     # some violation of DRY for the sake of better error messages at
@@ -149,7 +147,8 @@ when not defined(js):
       showPlot(tmpfile)
       sleep(1000)
       ## remove file after thread is finished
-      removeFile(tmpfile)
+      # commenting out is better; but do proper fix, see https://github.com/brentp/nim-plotly/issues/20
+      # removeFile(tmpfile)
 
     proc saveImage*(p: SomePlot, filename: string) =
       {.fatal: "`saveImage` only supported if compiled with --threads:on!".}

--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -110,16 +110,14 @@ when not defined(js):
                               "title", title, "saveImage", imageInject]
 
   proc save*(p: SomePlot, path = "", html_template = defaultTmplString, filename = ""): string =
-    let tempName = "D20190125T182937.html"
-      # unlikely to conflict with other applications
-      # TODO: implement https://github.com/brentp/nim-plotly/issues/20
-
     result = path
     if result == "":
-      when defined(Windows):
-        result = getEnv("TEMP") / tempName
-      else:
-        result = "/tmp/" & tempName
+      let dir = getTempDir() / "nimplotly"
+      createDir dir
+      # TODO: this unlikely to conflict with other applications but should
+      # implement https://github.com/brentp/nim-plotly/issues/20
+      # to avoid interference with multiple instances of this library
+      result = dir / "D20190125T182937.html"
 
     when type(p) is Plot:
       # convert traces to data suitable for plotly and fill Html template

--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -143,10 +143,7 @@ when not defined(js):
       let tmpfile = p.save(path, html_template)
 
       showPlot(tmpfile)
-      sleep(1000)
-      ## remove file after thread is finished
-      # commenting out is better; but do proper fix, see https://github.com/brentp/nim-plotly/issues/20
-      # removeFile(tmpfile)
+      # todo: garbage collect `tmpfile`, see https://github.com/brentp/nim-plotly/issues/20
 
     proc saveImage*(p: SomePlot, filename: string) =
       {.fatal: "`saveImage` only supported if compiled with --threads:on!".}
@@ -168,7 +165,7 @@ when not defined(js):
       if filename.len > 0:
         # wait for thread to join
         thr.joinThread
-      removeFile(tmpfile)
+      # todo: garbage collect `tmpfile`, see https://github.com/brentp/nim-plotly/issues/20
 
     proc saveImage*(p: SomePlot, filename: string) =
       ## saves the image under the given filename

--- a/src/plotly/tmpl_html.nim
+++ b/src/plotly/tmpl_html.nim
@@ -1,20 +1,35 @@
+proc removeComments(a: string): string=
+  ## removes lines starting with `#` (convenient; avoids having to use html comments when making edits)
+  for a in a.splitLines:
+    if a.strip.startsWith "#": continue
+    result.add a & "\n"
+
 const defaultTmplString = """
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="utf-8" />
-		<title>$title</title>
-		 <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-	</head>
-	<body>
-		<div id="plot0"></div>
-		<script>
-			Plotly.newPlot('plot0', $data, $layout)
-                </script>
-                $saveImage
-	</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>$title</title>
+     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  </head>
+  <body>
+    <div id="plot0"></div>
+    <script>
+        # TODO: this currently overrides size settings given in plots;
+        # need to expose whether to autoresize or not
+        # Note: this didn't seem to work: Plotly.Plots.resize('plot0');
+        runRelayout = function() {
+          var margin = 50; // if 0, would introduce scrolling
+          Plotly.relayout('plot0', {width: window.innerWidth - margin, height: window.innerHeight - margin } );
+        };
+        window.onresize = runRelayout;
+       # Consider: {responsive: true}
+       Plotly.newPlot('plot0', $data, $layout).then(runRelayout);
+    </script>
+    $saveImage
+  </body>
 </html>
-"""
+""".removeComments
 
 # type needs to be inserted!
 # either
@@ -37,7 +52,7 @@ const injectImageCode = """
           // need to wait a short while to be sure the promise is fullfilled (I believe?!)
           connection.send("connected")
           setTimeout(function(){ connection.send(imageData); }, 100);
-};
+        };
 </script>
 """
 


### PR DESCRIPTION

* fixes https://github.com/brentp/nim-plotly/issues/38
* partially addresses https://github.com/brentp/nim-plotly/issues/20
* some code cleanups
* `quit` is nasty and shd rarely be used, see https://forum.nim-lang.org/t/4042 ; now; it'll just throw on error (and give the relevant path in exception msg)

/cc @Vindaar @brentp
caveat: this will ignore given size settings; auto resize is a better default than a fixed arbitrary size, but we shd honor size if provided by user; let me know if u have a quick way to patch this PR to do that