### PR TITLE
fix link to docs in README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## nim-plotly: simple plots in nim
 
-[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://brentp.github.io/nim-plotly/plotly.html)
+[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://scinim.github.io/nim-plotly/)
 [![plotly CI](https://github.com/SciNim/nim-plotly/actions/workflows/ci.yml/badge.svg)](https://github.com/SciNim/nim-plotly/actions/workflows/ci.yml)
 
 This is a functioning plotting library. It supports, *line* (with fill below), *scatter* (with errors), *bar*

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.3.1
+- fix link to docs in the README
 * v0.3.0
 - =nim-plotly= now lives under the SciNim organization
 - adds option for auto resizing of plots (=autoResize= argument to


### PR DESCRIPTION
The badge in the README was still linking to the old docs page.