### PR TITLE
add threads:off to examples config file

### DIFF
--- a/examples/fig18_subplots.nims
+++ b/examples/fig18_subplots.nims
@@ -1,0 +1,1 @@
+--threads:off


### PR DESCRIPTION
Hello the maintainers of the nim-plotly. Nim v2 will make `threads:on` derfault. It seems that nim-plotly behaves differently with and without `threads:on`. So I add a config file to make sure it continues to compile.

Ref https://github.com/nim-lang/Nim/pull/19368