### PR TITLE
fix `show` for `Grid` when `threads:on` if no filename given

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.3.2
+- fix behavior of =show= when =--threads:on= for =Grid= usage, in
+  particular for example 18. =filename= argument is now optional,
+  implying just viewing a plot when none given instead of saving.
 * v0.3.1
 - fix link to docs in the README
 * v0.3.0

--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -330,7 +330,7 @@ else:
 
   when not defined(js):
     proc show*(grid: Grid,
-               filename: string,
+               filename = "",
                htmlPath = "",
                htmlTemplate = defaultTmplString,
                removeTempFile = false,


### PR DESCRIPTION
`show` should work for a `Grid` even with threads on when no filename
is given (implying just showing, but not saving a plot).